### PR TITLE
Represent MethodChannel methods with enums in Dart and WIndows C++

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  wg_dart:
+  wireguard_dart:
     # When depending on this package from a real application you should use:
     #   wg_dart: ^x.y.z
     # See https://dart.dev/tools/pub/dependencies#version-constraints

--- a/lib/wireguard_dart_method_channel.dart
+++ b/lib/wireguard_dart_method_channel.dart
@@ -8,6 +8,21 @@ import 'package:wireguard_dart/tunnel_statistics.dart';
 
 import 'wireguard_dart_platform_interface.dart';
 
+enum WireguardMethodChannelMethod {
+  generateKeyPair('generateKeyPair'),
+  nativeInit('nativeInit'),
+  setupTunnel('setupTunnel'),
+  connect('connect'),
+  disconnect('disconnect'),
+  status('status'),
+  checkTunnelConfiguration('checkTunnelConfiguration'),
+  removeTunnelConfiguration('removeTunnelConfiguration'),
+  tunnelStatistics('tunnelStatistics');
+
+  const WireguardMethodChannelMethod(this.value);
+  final String value;
+}
+
 class MethodChannelWireguardDart extends WireguardDartPlatform {
   @visibleForTesting
   final methodChannel = const MethodChannel('wireguard_dart');
@@ -15,8 +30,7 @@ class MethodChannelWireguardDart extends WireguardDartPlatform {
 
   @override
   Future<KeyPair> generateKeyPair() async {
-    final result = await methodChannel.invokeMapMethod<String, String>('generateKeyPair') ??
-        <String, String>{};
+    final result = await methodChannel.invokeMapMethod<String, String>(WireguardMethodChannelMethod.generateKeyPair.value) ?? <String, String>{};
     if (!result.containsKey('publicKey') || !result.containsKey('privateKey')) {
       throw StateError('Could not generate keypair');
     }
@@ -25,42 +39,38 @@ class MethodChannelWireguardDart extends WireguardDartPlatform {
 
   @override
   Future<void> nativeInit() async {
-    await methodChannel.invokeMethod<void>('nativeInit');
+    await methodChannel.invokeMethod<void>(WireguardMethodChannelMethod.nativeInit.value);
   }
 
   @override
-  Future<void> setupTunnel(
-      {required String bundleId, required String tunnelName, String? win32ServiceName}) async {
+  Future<void> setupTunnel({required String bundleId, required String tunnelName, String? win32ServiceName}) async {
     final args = {
       'bundleId': bundleId,
       'tunnelName': tunnelName,
       if (win32ServiceName != null) 'win32ServiceName': win32ServiceName,
     };
-    await methodChannel.invokeMethod<void>('setupTunnel', args);
+    await methodChannel.invokeMethod<void>(WireguardMethodChannelMethod.setupTunnel.value, args);
   }
 
   @override
   Future<void> connect({required String cfg}) async {
-    await methodChannel.invokeMethod<void>('connect', {'cfg': cfg});
+    await methodChannel.invokeMethod<void>(WireguardMethodChannelMethod.connect.value, {'cfg': cfg});
   }
 
   @override
   Future<void> disconnect() async {
-    await methodChannel.invokeMethod<void>('disconnect');
+    await methodChannel.invokeMethod<void>(WireguardMethodChannelMethod.disconnect.value);
   }
 
   @override
   Future<ConnectionStatus> status() async {
-    final result = await methodChannel.invokeMethod<String>('status');
+    final result = await methodChannel.invokeMethod<String>(WireguardMethodChannelMethod.status.value);
     return ConnectionStatus.fromString(result ?? "");
   }
 
   @override
   Stream<ConnectionStatus> statusStream() {
-    return statusChannel
-        .receiveBroadcastStream()
-        .distinct()
-        .map((val) => ConnectionStatus.fromString(val));
+    return statusChannel.receiveBroadcastStream().distinct().map((val) => ConnectionStatus.fromString(val));
   }
 
   @override
@@ -68,7 +78,7 @@ class MethodChannelWireguardDart extends WireguardDartPlatform {
     required String bundleId,
     required String tunnelName,
   }) async {
-    final result = await methodChannel.invokeMethod<bool>('checkTunnelConfiguration', {
+    final result = await methodChannel.invokeMethod<bool>(WireguardMethodChannelMethod.checkTunnelConfiguration.value, {
       'bundleId': bundleId,
       'tunnelName': tunnelName,
     });
@@ -76,9 +86,8 @@ class MethodChannelWireguardDart extends WireguardDartPlatform {
   }
 
   @override
-  Future<void> removeTunnelConfiguration(
-      {required String bundleId, required String tunnelName}) async {
-    await methodChannel.invokeMethod<void>('removeTunnelConfiguration', {
+  Future<void> removeTunnelConfiguration({required String bundleId, required String tunnelName}) async {
+    await methodChannel.invokeMethod<void>(WireguardMethodChannelMethod.removeTunnelConfiguration.value, {
       'bundleId': bundleId,
       'tunnelName': tunnelName,
     });
@@ -87,7 +96,7 @@ class MethodChannelWireguardDart extends WireguardDartPlatform {
   @override
   Future<TunnelStatistics?> getTunnelStatistics() async {
     try {
-      final result = await methodChannel.invokeMethod('tunnelStatistics');
+      final result = await methodChannel.invokeMethod(WireguardMethodChannelMethod.tunnelStatistics.value);
       final stats = TunnelStatistics.fromJson(jsonDecode(result));
       return stats;
     } catch (e) {

--- a/windows/wireguard_dart_plugin.h
+++ b/windows/wireguard_dart_plugin.h
@@ -5,28 +5,56 @@
 #include <flutter/plugin_registrar_windows.h>
 
 #include <memory>
+#include <optional>
 
-#include "service_control.h"
 #include "connection_status_observer.h"
+#include "service_control.h"
 
 namespace wireguard_dart {
 
+enum class WireguardMethod {
+  GENERATE_KEY_PAIR,
+  CHECK_TUNNEL_CONFIGURATION,
+  NATIVE_INIT,
+  SETUP_TUNNEL,
+  CONNECT,
+  DISCONNECT,
+  STATUS
+};
+
 class WireguardDartPlugin : public flutter::Plugin {
  public:
-  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar);
 
   WireguardDartPlugin();
 
   virtual ~WireguardDartPlugin();
 
   // Disallow copy and assign.
-  WireguardDartPlugin(const WireguardDartPlugin &) = delete;
-  WireguardDartPlugin &operator=(const WireguardDartPlugin &) = delete;
+  WireguardDartPlugin(const WireguardDartPlugin&) = delete;
+  WireguardDartPlugin& operator=(const WireguardDartPlugin&) = delete;
 
  private:
   // Called when a method is called on this plugin's channel from Dart.
-  void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue> &method_call,
+  void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& method_call,
                         std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+  // Helper methods for each supported method
+  std::optional<WireguardMethod> GetMethodFromString(const std::string& method_name);
+  void HandleGenerateKeyPair(const flutter::EncodableMap* args,
+                             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void HandleCheckTunnelConfiguration(const flutter::EncodableMap* args,
+                                      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void HandleNativeInit(const flutter::EncodableMap* args,
+                        std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void HandleSetupTunnel(const flutter::EncodableMap* args,
+                         std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void HandleConnect(const flutter::EncodableMap* args,
+                     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void HandleDisconnect(const flutter::EncodableMap* args,
+                        std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void HandleStatus(const flutter::EncodableMap* args,
+                    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
   std::unique_ptr<ServiceControl> tunnel_service_;
   std::unique_ptr<ConnectionStatusObserver> connection_status_observer_;


### PR DESCRIPTION
Represents the known methods as enums, to make it easier to see what is available and what is implemented.